### PR TITLE
feat: Add "Code of Conduct" page

### DIFF
--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -4,6 +4,10 @@
 		"url": "/"
 	},
 	{
+		"text": "Code of Conduct",
+		"url": "/conduct"
+	},
+	{
 		"text": "Teachers",
 		"url": "/teachers"
 	},

--- a/src/conduct.md
+++ b/src/conduct.md
@@ -1,0 +1,40 @@
+---
+layout: 'layouts/home'
+title: "Code of Conduct"
+---
+
+Our events are social and learning experiences where we want people to feel comfortable, and we aim to provide a harassment-free and safe social dance experience for everyone regardless of dance experience, gender, gender identity and expression, sexual orientation, physical ability, appearance, body size, race, age, religion or any other characteristic.
+
+We take zero tolerance to harassment in any form: individuals violating these rules will be warned or expelled from the venue at the discretion of the organisers. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact any of the event organisers immediately. Ask the sign-in/registration desk if you need assistance locating an organiser.
+
+Harassment includes, but is not limited to: deliberate intimidation, stalking, unwanted or intrusive photography or videography, inappropriate physical contact (including unsolicited affection), sexual behaviour in public spaces, and unwelcome and unreciprocated sexual attention. When asked to stop any harassing behaviour, participants are expected to comply immediately.
+
+Unsafe behaviour includes, but is not limited to: dipping too deeply or without permission, forceful movements that could cause injury to your partner, excessive use of alcohol, and any form of aerials/air steps without explicit consent, or on a social floor (i.e. outside of a performance or jam circle). It is perfectly acceptable to say no to a dance without reason.
+
+All dancers are expected to do their best to avoid colliding with others, to apologise if and when such collisions occur, and to ensure that all dancers are safe before continuing to dance. Additionally we expect dancers to avoid interfering with others, except when given consent (e.g. in a steal, swap, or switch dance). Interference also includes unsolicited feedback in class or on the social dancefloor.
+
+
+## Breaches
+
+Any individual breaching this code of conduct at an event may expect (depending on the severity):
+
+* A verbal warning from an organiser, advising them to change their behaviour.
+* A formal warning from an organiser, stating that any further breaches will be grounds for further action.
+* Ejection from an individual event (e.g. dance, class etc) or overall event (e.g. dance weekend).
+* Banning from this and all future events run by the organisers.
+* Reporting of their actions to the legal authorities.
+
+Any action taken is at the discretion of the event organisers.
+
+## Issue Reporting
+
+If you experience or witness a breach of this code of conduct, you are empowered to notify an organiser immediately. If you do not want action taken in the moment, but later change your mind, do not hesitate to contact an organiser. The following is what to expect:
+
+* The safety officer will talk you privately in confidence.
+* The safety officer will then document the issue.
+* They will then ask you how you would like the situation to be handled.
+* Action will be taken against the individual(s) involved, in line with those listed in the "Breaches" section.
+
+There is a dedicated e-mail address that goes directly to the safety officer event should you wish to avoid discussing a violation with anyone else: [safety@emeraldswing.com](mailto:safety@emeraldswing.com).
+
+We appreciate your assistance in keeping our events as safe as possible for everyone.


### PR DESCRIPTION
This commit adds a page on the website for the code of conduct, which also includes the e-mail details for the Safety Officer of the event. Everyone had to read this code of conduct when signing up for the event: this ensures there's another place to find and reference it, with the third being at the desk during the event.